### PR TITLE
Forward opts as HTML attributes on the SVG tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.1.4 (WIP)
+
+- All options passed to `icon/3` will be added to the SVG tag as HTML attributes
+- Added `opts` prop to the Surface Icon component, which will be added to the SVG tag as HTML attributes
+
 ## v0.1.3 (2021-05-24)
 
 - Improve documentation

--- a/lib/heroicons.ex
+++ b/lib/heroicons.ex
@@ -43,6 +43,8 @@ defmodule Heroicons do
   @doc """
   Generates an icon.
 
+  All options are forwarded to the underlying SVG tag as HTML attributes.
+
   ## Options
 
     * `:class` - the css class added to the SVG tag
@@ -58,9 +60,10 @@ defmodule Heroicons do
   """
   def icon(type, name, opts \\ [])
 
-  for %{type: type, name: name, contents: contents} <- icons do
+  for %Icon{type: type, name: name, file: file} <- icons do
     def icon(unquote(type), unquote(name), opts) do
-      unquote(contents)
+      attrs = Icon.opts_to_attrs(opts)
+      Icon.insert_attrs(unquote(file), attrs)
     end
   end
 

--- a/lib/heroicons/components/icon.ex
+++ b/lib/heroicons/components/icon.ex
@@ -19,16 +19,22 @@ if Code.ensure_loaded?(Surface) do
     @doc "The class of the icon"
     prop class, :css_class
 
+    @doc "All options are forwarded to the underlying SVG tag as HTML attributes"
+    prop opts, :keyword, default: []
+
     def render(assigns) do
-      opts =
-        case Map.get(assigns, :class) do
-          nil -> []
-          class -> [class: Surface.css_class(class)]
-        end
+      opts = class_to_opts(assigns) ++ assigns.opts
 
       ~H"""
       {{ Heroicons.icon(@type, @name, opts) }}
       """
+    end
+
+    defp class_to_opts(assigns) do
+      case Map.get(assigns, :class) do
+        nil -> []
+        class -> [class: Surface.css_class(class)]
+      end
     end
   end
 end

--- a/lib/heroicons/icon.ex
+++ b/lib/heroicons/icon.ex
@@ -3,26 +3,33 @@ defmodule Heroicons.Icon do
   This module defines the data structure and functions for working with icons stored as SVG files.
   """
 
-  defstruct [:type, :name, :contents]
+  defstruct [:type, :name, :file]
 
   @doc "Parses a SVG file and returns structured data"
   def parse!(filename) do
     [type, name] = filename |> Path.split() |> Enum.take(-2)
-
     name = Path.rootname(name)
+    file = File.read!(filename)
+    struct!(__MODULE__, type: type, name: name, file: file)
+  end
 
-    options = [
-      engine: Phoenix.HTML.Engine,
-      line: 1,
-      indentation: 0
-    ]
+  @doc "Converts opts to HTML attributes"
+  def opts_to_attrs(opts) do
+    for {key, value} <- opts do
+      key =
+        key
+        |> Atom.to_string()
+        |> String.replace("_", "-")
+        |> Phoenix.HTML.Safe.to_iodata()
 
-    contents =
-      filename
-      |> File.read!()
-      |> String.replace("<svg", ~s(<svg class="<%= opts[:class] %>"))
-      |> EEx.compile_string(options)
+      value = Phoenix.HTML.Safe.to_iodata(value)
 
-    struct!(__MODULE__, type: type, name: name, contents: contents)
+      [?\s, key, ?=, ?", value, ?"]
+    end
+  end
+
+  @doc "Inserts HTML attributes into an SVG icon"
+  def insert_attrs("<svg" <> rest, attrs) do
+    Phoenix.HTML.raw(["<svg", attrs, rest])
   end
 end

--- a/test/components/icon_test.exs
+++ b/test/components/icon_test.exs
@@ -28,6 +28,28 @@ defmodule Heroicons.Components.IconTest do
     assert html =~ ~s(<svg class="h-4 w-4")
   end
 
+  test "renders icon with opts" do
+    html =
+      render_surface do
+        ~H"""
+        <Icon type="outline" name="academic-cap" opts={{ aria_hidden: true }} />
+        """
+      end
+
+    assert html =~ ~s(<svg aria-hidden="true")
+  end
+
+  test "class prop overrides opts prop" do
+    html =
+      render_surface do
+        ~H"""
+        <Icon type="outline" name="academic-cap" class="hello" opts={{ class: "world" }} />
+        """
+      end
+
+    assert html =~ ~s(<svg class="hello")
+  end
+
   test "raises if type or icon don't exist" do
     msg = ~s(icon of type "hello" with name "academic-cap" does not exist.)
 

--- a/test/heroicons_test.exs
+++ b/test/heroicons_test.exs
@@ -7,9 +7,14 @@ defmodule HeroiconsTest do
            |> Phoenix.HTML.safe_to_string() =~ "<svg"
   end
 
-  test "renders icon with class" do
+  test "renders icon with attribute" do
     assert Heroicons.icon("outline", "academic-cap", class: "h-4 w-4")
            |> Phoenix.HTML.safe_to_string() =~ ~s(<svg class="h-4 w-4")
+  end
+
+  test "converts opts to attributes" do
+    assert Heroicons.icon("outline", "academic-cap", aria_hidden: true)
+           |> Phoenix.HTML.safe_to_string() =~ ~s(<svg aria-hidden="true")
   end
 
   test "raises if type or icon don't exist" do


### PR DESCRIPTION
So far it's only possible to pass a `class` option to the SVG tag.

With this change it will be possible to pass any option which will be converted to a HTML attribute on the SVG tag.

### Examples

#### Eex and Leex

```elixir
<%= Heroicons.icon("outline", "academic-cap", class: "h-4 w-4", aria_hidden: true) %>
```

#### Surface

```elixir
<Icon type="outline" name="academic-cap" class="h-4 w-4" opts={{ aria_hidden: true }} />
```