### PR TITLE
Add `:type` config for setting the default icon type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v0.1.5-dev
+
+#### Breaking Changes
+
+- Replaced `icon/3` with `icon/2`, the `type` argument should be passed as an option instead
+
+#### Enhancements
+
+- Added `:type` to config for setting the default icon type
+
 ## v0.1.4 (2021-05-29)
 
 - All options passed to `icon/3` will be added to the SVG tag as HTML attributes
@@ -5,15 +15,15 @@
 
 ## v0.1.3 (2021-05-24)
 
-- Improve documentation
+- Improved documentation
 
 ## v0.1.2 (2021-05-22)
 
-- Fix Surface Icon component error when not passing the class prop
+- Fixed Surface Icon component error when not passing the class prop
 
 ## v0.1.1 (2021-05-19)
 
-- Add Surface Icon component
+- Added Surface Icon component
 
 ## v0.1.0 (2021-05-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.1.5-dev
+## v0.2.0-dev
 
 #### Breaking Changes
 

--- a/README.md
+++ b/README.md
@@ -25,14 +25,26 @@ Then run `mix deps.get`.
 
 ## Usage
 
-### With Eex or Leex
+#### With Eex or Leex
 
 ```elixir
-<%= Heroicons.icon("outline", "academic-cap", class: "h-4 w-4") %>
+<%= Heroicons.icon("academic-cap", type: "outline", class: "h-4 w-4") %>
 ```
 
-### With Surface
+#### With Surface
 
 ```elixir
-<Heroicons.Components.Icon type="outline" name="academic-cap" class="h-4 w-4" />
+<Heroicons.Components.Icon name="academic-cap" type="outline" class="h-4 w-4" />
 ```
+
+## Config
+
+Defaults can be set in the `Heroicons` application configuration.
+
+```elixir
+config :ex_heroicons, type: "outline"
+```
+
+## License
+
+MIT. See [LICENSE](https://github.com/miguel-s/ex_heroicon/blob/master/LICENSE) for more details.

--- a/lib/heroicons/components/icon.ex
+++ b/lib/heroicons/components/icon.ex
@@ -5,16 +5,20 @@ if Code.ensure_loaded?(Surface) do
 
     ## Examples
 
-        <Heroicons.Components.Icon type="outline" name="academic-cap" class="h-4 w-4" />
+        <Heroicons.Components.Icon name="academic-cap" type="outline" class="h-4 w-4" />
     """
 
     use Surface.Component
 
-    @doc "The type of the icon"
-    prop type, :string, values: ["outline", "solid"], required: true
-
     @doc "The name of the icon"
     prop name, :string, required: true
+
+    @doc """
+    The type of the icon
+
+    Required if default type is not configured.
+    """
+    prop type, :string
 
     @doc "The class of the icon"
     prop class, :css_class
@@ -23,17 +27,27 @@ if Code.ensure_loaded?(Surface) do
     prop opts, :keyword, default: []
 
     def render(assigns) do
-      opts = class_to_opts(assigns) ++ assigns.opts
-
       ~H"""
-      {{ Heroicons.icon(@type, @name, opts) }}
+      {{ Heroicons.icon(@name, type_to_opts(@type) ++ class_to_opts(@class) ++ @opts) }}
       """
     end
 
-    defp class_to_opts(assigns) do
-      case Map.get(assigns, :class) do
-        nil -> []
-        class -> [class: Surface.css_class(class)]
+    defp type_to_opts(type) do
+      type = type || Heroicons.default_type()
+
+      unless type do
+        raise ArgumentError,
+              "type prop is required if default type is not configured."
+      end
+
+      [type: type]
+    end
+
+    defp class_to_opts(class) do
+      if class do
+        [class: Surface.css_class(class)]
+      else
+        []
       end
     end
   end

--- a/test/components/icon_test.exs
+++ b/test/components/icon_test.exs
@@ -14,7 +14,7 @@ defmodule Heroicons.Components.IconTest do
 
     def render(assigns) do
       ~H"""
-      <Icon type="outline" name="academic-cap" opts={{ aria_hidden: @aria_hidden }} />
+      <Icon name="academic-cap" type="outline" opts={{ aria_hidden: @aria_hidden }} />
       """
     end
   end
@@ -23,7 +23,7 @@ defmodule Heroicons.Components.IconTest do
     html =
       render_surface do
         ~H"""
-        <Icon type="outline" name="academic-cap" />
+        <Icon name="academic-cap" type="outline" />
         """
       end
 
@@ -34,7 +34,7 @@ defmodule Heroicons.Components.IconTest do
     html =
       render_surface do
         ~H"""
-        <Icon type="outline" name="academic-cap" class="h-4 w-4" />
+        <Icon name="academic-cap" type="outline" class="h-4 w-4" />
         """
       end
 
@@ -45,7 +45,7 @@ defmodule Heroicons.Components.IconTest do
     html =
       render_surface do
         ~H"""
-        <Icon type="outline" name="academic-cap" opts={{ aria_hidden: true }} />
+        <Icon name="academic-cap" type="outline" opts={{ aria_hidden: true }} />
         """
       end
 
@@ -56,30 +56,44 @@ defmodule Heroicons.Components.IconTest do
     html =
       render_surface do
         ~H"""
-        <Icon type="outline" name="academic-cap" class="hello" opts={{ class: "world" }} />
+        <Icon name="academic-cap" type="outline" class="hello" opts={{ class: "world" }} />
         """
       end
 
     assert html =~ ~s(<svg class="hello")
   end
 
-  test "raises if type or icon don't exist" do
-    msg = ~s(icon of type "hello" with name "academic-cap" does not exist.)
+  test "raises if icon name does not exist" do
+    msg = ~s(icon "hello" with type "outline" does not exist.)
 
     assert_raise ArgumentError, msg, fn ->
       render_surface do
         ~H"""
-        <Icon type="hello" name="academic-cap" />
+        <Icon name="hello" type="outline" />
         """
       end
     end
+  end
 
-    msg = ~s(icon of type "outline" with name "world" does not exist.)
+  test "raises if type is missing" do
+    msg = ~s(type prop is required if default type is not configured.)
 
     assert_raise ArgumentError, msg, fn ->
       render_surface do
         ~H"""
-        <Icon type="outline" name="world" />
+        <Icon name="hello" />
+        """
+      end
+    end
+  end
+
+  test "raises if icon type does not exist" do
+    msg = ~s(expected type to be one of #{inspect(Heroicons.types())}, got: "world")
+
+    assert_raise ArgumentError, msg, fn ->
+      render_surface do
+        ~H"""
+        <Icon name="academic-cap" type="world" />
         """
       end
     end
@@ -95,5 +109,38 @@ defmodule Heroicons.Components.IconTest do
 
     assert render_click(view, :toggle_aria_hidden) =~
              ~s(<svg aria-hidden="false")
+  end
+end
+
+defmodule Heroicons.Components.IconConfigTest do
+  use Heroicons.ConnCase
+
+  alias Heroicons.Components.Icon
+
+  test "renders icon with default type" do
+    Application.put_env(:ex_heroicons, :type, "outline")
+
+    html =
+      render_surface do
+        ~H"""
+        <Icon name="academic-cap" />
+        """
+      end
+
+    assert html =~ "<svg"
+  end
+
+  test "raises if default icon type does not exist" do
+    Application.put_env(:ex_heroicons, :type, "world")
+
+    msg = ~s(expected default type to be one of #{inspect(Heroicons.types())}, got: "world")
+
+    assert_raise ArgumentError, msg, fn ->
+      render_surface do
+        ~H"""
+        <Icon name="academic-cap" />
+        """
+      end
+    end
   end
 end

--- a/test/heroicons_test.exs
+++ b/test/heroicons_test.exs
@@ -3,31 +3,62 @@ defmodule HeroiconsTest do
   doctest Heroicons
 
   test "renders icon" do
-    assert Heroicons.icon("outline", "academic-cap")
+    assert Heroicons.icon("academic-cap", type: "outline")
            |> Phoenix.HTML.safe_to_string() =~ "<svg"
   end
 
   test "renders icon with attribute" do
-    assert Heroicons.icon("outline", "academic-cap", class: "h-4 w-4")
+    assert Heroicons.icon("academic-cap", type: "outline", class: "h-4 w-4")
            |> Phoenix.HTML.safe_to_string() =~ ~s(<svg class="h-4 w-4")
   end
 
   test "converts opts to attributes" do
-    assert Heroicons.icon("outline", "academic-cap", aria_hidden: true)
+    assert Heroicons.icon("academic-cap", type: "outline", aria_hidden: true)
            |> Phoenix.HTML.safe_to_string() =~ ~s(<svg aria-hidden="true")
   end
 
-  test "raises if type or icon don't exist" do
-    msg = ~s(icon of type "hello" with name "academic-cap" does not exist.)
+  test "raises if icon name does not exist" do
+    msg = ~s(icon "hello" with type "outline" does not exist.)
 
     assert_raise ArgumentError, msg, fn ->
-      Heroicons.icon("hello", "academic-cap")
+      Heroicons.icon("hello", type: "outline")
     end
+  end
 
-    msg = ~s(icon of type "outline" with name "world" does not exist.)
+  test "raises if type is missing" do
+    msg = ~s(expected type in options, got: [])
 
     assert_raise ArgumentError, msg, fn ->
-      Heroicons.icon("outline", "world")
+      Heroicons.icon("academic-cap")
+    end
+  end
+
+  test "raises if icon type does not exist" do
+    msg = ~s(expected type to be one of #{inspect(Heroicons.types())}, got: "world")
+
+    assert_raise ArgumentError, msg, fn ->
+      Heroicons.icon("academic-cap", type: "world")
+    end
+  end
+end
+
+defmodule HeroiconsConfigTest do
+  use ExUnit.Case
+
+  test "renders icon with default type" do
+    Application.put_env(:ex_heroicons, :type, "outline")
+
+    assert Heroicons.icon("academic-cap")
+           |> Phoenix.HTML.safe_to_string() =~ "<svg"
+  end
+
+  test "raises if default icon type does not exist" do
+    Application.put_env(:ex_heroicons, :type, "world")
+
+    msg = ~s(expected default type to be one of #{inspect(Heroicons.types())}, got: "world")
+
+    assert_raise ArgumentError, msg, fn ->
+      Heroicons.icon("academic-cap")
     end
   end
 end


### PR DESCRIPTION
This PR introduces the `:type` config for setting the default icon type.

Related to #5 

#### Goal

Improve DX by removing the need to repeat the (default) type each time an icon is used.

#### Usage

In your `config.exs` add:

```elixir
config :ex_heroicons, type: "outline" # or "solid"
```

Which will allow to omit the `type` option/prop:

Eex and Leex
```elixir
<%= Heroicons.icon("academic-cap", class: "h-4 w-4") %>
```

Surface
```elixir
<Heroicons.Components.Icon name="academic-cap" class="h-4 w-4" />
```

#### Breaking Changes

Replaced `icon/3` with `icon/2`, the `type` argument should be passed as an option instead.

Before
```elixir
Heroicons.icon("outline", "academic-cap", class: "h-4 w-4")
```

After
```elixir
Heroicons.icon("academic-cap", type: "outline", class: "h-4 w-4")
```