### PR TITLE
Updated fill and stroke colors to match heroicons.com

### DIFF
--- a/lib/heroicons.ex
+++ b/lib/heroicons.ex
@@ -144,10 +144,10 @@ defmodule Heroicons do
     ~H"""
     <svg
       xmlns="http://www.w3.org/2000/svg"
-      fill="none"
+      fill={fill_color(@type)}
       viewBox={svg_viewbox(@type)}
       stroke-width="1.5"
-      stroke="currentColor"
+      stroke={stroke_color(@type)}
       aria-hidden="true"
       data-slot="icon"
       class={@class}
@@ -166,6 +166,14 @@ defmodule Heroicons do
       "outline" -> "0 0 24 24"
     end
   end
+
+  defp fill_color("outline"), do: "none"
+
+  defp fill_color(_), do: "currentColor"
+
+  defp stroke_color("outline"), do: "currentColor"
+
+  defp stroke_color(_), do: "none"
 
   for %Icon{name: name, type: type, file: file} <- icons do
     defp svg_body(unquote(name), unquote(type)) do

--- a/test/heroicons_test.exs
+++ b/test/heroicons_test.exs
@@ -38,28 +38,28 @@ defmodule HeroiconsTest do
 
   test "renders micro icon with fill of currentColor and no stroke" do
     assigns = %{}
-    html = rendered_to_string(~h[<heroicons.icon name="academic-cap" type="micro" />])
-    assert html =~ ~s(fill="currentcolor")
+    html = rendered_to_string(~H[<Heroicons.icon name="academic-cap" type="micro" />])
+    assert html =~ ~s(fill="currentColor")
     assert html =~ ~s(stroke="none")
   end
 
   test "renders mini icon with fill of currentColor and no stroke" do
     assigns = %{}
-    html = rendered_to_string(~h[<heroicons.icon name="academic-cap" type="mini" />])
-    assert html =~ ~s(fill="currentcolor")
+    html = rendered_to_string(~H[<Heroicons.icon name="academic-cap" type="mini" />])
+    assert html =~ ~s(fill="currentColor")
     assert html =~ ~s(stroke="none")
   end
 
   test "renders solid icon with fill of currentColor and no stroke" do
     assigns = %{}
-    html = rendered_to_string(~h[<heroicons.icon name="academic-cap" type="solid" />])
-    assert html =~ ~s(fill="currentcolor")
+    html = rendered_to_string(~H[<Heroicons.icon name="academic-cap" type="solid" />])
+    assert html =~ ~s(fill="currentColor")
     assert html =~ ~s(stroke="none")
   end
 
   test "renders outline icon with no fill and stroke of currentColor" do
     assigns = %{}
-    html = rendered_to_string(~h[<heroicons.icon name="academic-cap" type="outline" />])
+    html = rendered_to_string(~H[<Heroicons.icon name="academic-cap" type="outline" />])
     assert html =~ ~s(fill="none")
     assert html =~ ~s(stroke="currentColor")
   end

--- a/test/heroicons_test.exs
+++ b/test/heroicons_test.exs
@@ -36,6 +36,34 @@ defmodule HeroiconsTest do
     assert html =~ ~s(aria-hidden="true")
   end
 
+  test "renders micro icon with fill of currentColor and no stroke" do
+    assigns = %{}
+    html = rendered_to_string(~h[<heroicons.icon name="academic-cap" type="micro" />])
+    assert html =~ ~s(fill="currentcolor")
+    assert html =~ ~s(stroke="none")
+  end
+
+  test "renders mini icon with fill of currentColor and no stroke" do
+    assigns = %{}
+    html = rendered_to_string(~h[<heroicons.icon name="academic-cap" type="mini" />])
+    assert html =~ ~s(fill="currentcolor")
+    assert html =~ ~s(stroke="none")
+  end
+
+  test "renders solid icon with fill of currentColor and no stroke" do
+    assigns = %{}
+    html = rendered_to_string(~h[<heroicons.icon name="academic-cap" type="solid" />])
+    assert html =~ ~s(fill="currentcolor")
+    assert html =~ ~s(stroke="none")
+  end
+
+  test "renders outline icon with no fill and stroke of currentColor" do
+    assigns = %{}
+    html = rendered_to_string(~h[<heroicons.icon name="academic-cap" type="outline" />])
+    assert html =~ ~s(fill="none")
+    assert html =~ ~s(stroke="currentColor")
+  end
+
   test "raises when icon name is not found" do
     assigns = %{}
 


### PR DESCRIPTION
Only outline icons should have a stroke of `currentColor` and all other icons should have a fill of `currentColor` by default.

https://heroicons.com/outline
```svg
<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6">
  <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
</svg>
```
https://heroicons.com/solid
```svg
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6">
  <path fill-rule="evenodd" d="M7.5 6a4.5 4.5 0 1 1 9 0 4.5 4.5 0 0 1-9 0ZM3.751 20.105a8.25 8.25 0 0 1 16.498 0 .75.75 0 0 1-.437.695A18.683 18.683 0 0 1 12 22.5c-2.786 0-5.433-.608-7.812-1.7a.75.75 0 0 1-.437-.695Z" clip-rule="evenodd" />
</svg>
```
https://heroicons.com/mini
```svg
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="size-5">
  <path d="M10 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6ZM3.465 14.493a1.23 1.23 0 0 0 .41 1.412A9.957 9.957 0 0 0 10 18c2.31 0 4.438-.784 6.131-2.1.43-.333.604-.903.408-1.41a7.002 7.002 0 0 0-13.074.003Z" />
</svg>
```
https://heroicons.com/micro
```svg
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="size-4">
  <path d="M8 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6ZM12.735 14c.618 0 1.093-.561.872-1.139a6.002 6.002 0 0 0-11.215 0c-.22.578.254 1.139.872 1.139h9.47Z" />
</svg>
```